### PR TITLE
Upgrade to JUnit 5.5.0

### DIFF
--- a/java-datetime/pom.xml
+++ b/java-datetime/pom.xml
@@ -36,30 +36,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <includeTags>PASSING</includeTags>
-                        <excludeTags>TODO</excludeTags>
-                    </properties>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit5.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>

--- a/java-handles/pom.xml
+++ b/java-handles/pom.xml
@@ -37,12 +37,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <includeTags>PASSING</includeTags>
-                        <excludeTags>TODO</excludeTags>
-                    </properties>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/java-optional/pom.xml
+++ b/java-optional/pom.xml
@@ -36,30 +36,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <includeTags>PASSING</includeTags>
-                        <excludeTags>TODO</excludeTags>
-                    </properties>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit5.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
 
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.9.1</version>
                 <executions>
                     <execution>
                         <id>add-test-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
 
-        <apiguardian-api.version>1.0.0</apiguardian-api.version>
-        <opentest4j.version>1.1.1</opentest4j.version>
-
-        <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
-
-        <junit5.version>5.4.1</junit5.version>
+        <junit5.version>5.5.0</junit5.version>
     </properties>
 
     <dependencyManagement>
@@ -58,31 +53,23 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.21.0</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.junit.platform</groupId>
-                            <artifactId>junit-platform-surefire-provider</artifactId>
-                            <version>${junit-platform-surefire-provider.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.junit.jupiter</groupId>
-                            <artifactId>junit-jupiter-engine</artifactId>
-                            <version>${junit5.version}</version>
-                        </dependency>
-                    </dependencies>
+                    <version>2.22.2</version>
+                    <configuration>
+                        <groups>PASSING</groups>
+                        <excludedGroups>TODO</excludedGroups>
+                    </configuration>
                 </plugin>
 
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.9.1</version>
+                    <version>3.0.0</version>
                 </plugin>
 
             </plugins>


### PR DESCRIPTION
Remove deprecated Surefire Provider, Surefire provides native support for the JUnit Platform using its own provider.

Moved the configuration of "tag" to the parent POM. Tags are called groups within Surefire to re-use the names introduced for TestNG. See https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html for details. 

Upgrade other plugins.