### PR TITLE
rename classes to match surefire-plugin include pattern

### DIFF
--- a/java-optional/README.md
+++ b/java-optional/README.md
@@ -107,15 +107,15 @@ The JUnit tests listed below are setup to utilize the Java Optional API features
 
 #### Java Optional
 
-1. ##### [Test1OptionalCreationAndFetchingValues](src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValues.java)
+1. ##### [Test1OptionalCreationAndFetchingValuesTest.java](src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValuesTest.java)
 
    The tests in this class show creation of and fetching value from an Optional. 
 
-1. ##### [Test2OptionalConditionalFetching.java](src/test/java/none/cvg/optional/Test2OptionalConditionalFetching.java) 
+1. ##### [Test2OptionalConditionalFetchingTest.java](src/test/java/none/cvg/optional/Test2OptionalConditionalFetchingTest.java) 
 
    The tests in this class show conditional checks and alternate actions when fetching values from an Optional. 
 
-1. ##### [Test3StreamsAndOptionals.java](src/test/java/none/cvg/optional/Test3StreamsAndOptionals.java)
+1. ##### [Test3StreamsAndOptionalsTest.java](src/test/java/none/cvg/optional/Test3StreamsAndOptionalsTest.java)
 
    The tests in this class show the usage of Optional in Java Stream API. 
 
@@ -126,9 +126,9 @@ Solutions for each test:
 
 Kata Test | Solution
 ------------ | -------------
-[Test1OptionalCreationAndFetchingValues](src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValues.java) | [STest1OptionalCreationAndFetchingValues.java](src/solutions/java/none/cvg/optional/STest1OptionalCreationAndFetchingValues.java)
-[Test2OptionalConditionalFetching](src/test/java/none/cvg/optional/Test2OptionalConditionalFetching.java) | [STest2OptionalConditionalFetching.java](src/solutions/java/none/cvg/optional/STest2OptionalConditionalFetching.java)
-[Test3StreamsAndOptionals](src/test/java/none/cvg/optional/Test3StreamsAndOptionals.java) | [STest3StreamsAndOptionals.java](src/solutions/java/none/cvg/optional/STest3StreamsAndOptionals.java)
+[Test1OptionalCreationAndFetchingValuesTest.java](src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValuesTest.java) | [STest1OptionalCreationAndFetchingValuesTest.java](src/solutions/java/none/cvg/optional/STest1OptionalCreationAndFetchingValuesTest.java)
+[Test2OptionalConditionalFetchingTest.java](src/test/java/none/cvg/optional/Test2OptionalConditionalFetchingTest.java) | [STest2OptionalConditionalFetchingTest.java](src/solutions/java/none/cvg/optional/STest2OptionalConditionalFetchingTest.java)
+[Test3StreamsAndOptionalsTest.java](src/test/java/none/cvg/optional/Test3StreamsAndOptionalsTest.java) | [STest3StreamsAndOptionalsTest.java](src/solutions/java/none/cvg/optional/STest3StreamsAndOptionalsTest.java)
     
 
 ## <a name="TakeAway"></a>Take Away

--- a/java-optional/src/solutions/java/none/cvg/optional/STest1OptionalCreationAndFetchingValuesTest.java
+++ b/java-optional/src/solutions/java/none/cvg/optional/STest1OptionalCreationAndFetchingValuesTest.java
@@ -1,15 +1,16 @@
 package none.cvg.optional;
 
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-
-import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
- * TODO:
+ * DONE:
  *  This test aims at understanding the basic features of Optional
  *  Each unsolved test provides a few hints that will allow the kata-taker to manually solve
  *  the exercise.
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("java.util.Optional Creation And Getting value")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class Test1OptionalCreationAndFetchingValues {
+public class STest1OptionalCreationAndFetchingValuesTest {
 
     @BeforeEach
     public void setUp() {
@@ -35,16 +36,16 @@ public class Test1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create an empty Optional")
-    @Tag("TODO")
+    @Tag("PASSING")
     @Order(1)
     public void emptyOptional() {
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "null" to create an empty Optional.
          *  Check API: java.util.Optional.empty()
          */
-        Optional<String> optionalEmptyString = null;
+        Optional<String> optionalEmptyString = Optional.empty();
 
         assertTrue(optionalEmptyString instanceof Optional,
                 "The optionalEmptyString should be an instance of Optional");
@@ -55,18 +56,18 @@ public class Test1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create an Optional from a variable")
-    @Tag("TODO")
+    @Tag("PASSING")
     @Order(2)
     public void createOptionalFromValue() {
 
         Integer anInteger = 10;
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "null" to create an Optional for anInteger.
          *  Check API: java.util.Optional.of(?)
          */
-        Optional<Integer> optionalForInteger = null;
+        Optional<Integer> optionalForInteger = Optional.of(anInteger);
 
         assertTrue(optionalForInteger instanceof Optional,
                 "The optionalEmptyString should be an instance of Optional");
@@ -77,18 +78,18 @@ public class Test1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create a nullable Optional from a variable")
-    @Tag("TODO")
+    @Tag("PASSING")
     @Order(3)
     public void createNullableOptionalFromValue() {
 
         Integer anInteger = null;
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "null" to create a nullable Optional for anInteger.
          *  Check API: java.util.Optional.ofNullable(?)
          */
-        Optional<Integer> optionalNullableInteger = Optional.of(10);
+        Optional<Integer> optionalNullableInteger = Optional.ofNullable(anInteger);
 
         assertTrue(optionalNullableInteger instanceof Optional,
                 "The optionalNullableInteger should be an instance of Optional");
@@ -99,7 +100,7 @@ public class Test1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("check a non-null Optional has a value")
-    @Tag("TODO")
+    @Tag("PASSING")
     @Order(4)
     public void checkOptionalForNonNullValueIsPresent() {
 
@@ -108,11 +109,11 @@ public class Test1OptionalCreationAndFetchingValues {
         Optional<Integer> optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "false" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.isPresent()
          */
-        assertTrue(false,
+        assertTrue(optionalInteger.isPresent(),
                 "The optionalNullableInteger should be present");
 
 
@@ -121,18 +122,18 @@ public class Test1OptionalCreationAndFetchingValues {
         optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "false" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.isPresent()
          */
-        assertFalse(true,
+        assertFalse(optionalInteger.isPresent(),
                 "The optionalNullableInteger should not be present");
 
     }
 
     @Test
     @DisplayName("fetch from a non-null and from a null holding Optional")
-    @Tag("TODO")
+    @Tag("PASSING")
     @Order(5)
     public void getValueFromOptionalForNonNullValue() {
 
@@ -141,12 +142,12 @@ public class Test1OptionalCreationAndFetchingValues {
         Optional<Integer> optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * TODO:
-         *  Replace the "11" to check that the Optional has a non-null value.
+         * DONE:
+         *  Replace the "null" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.get()
          */
         assertEquals(10,
-                11,
+                optionalInteger.get(),
                 "The optionalNullableInteger should be present");
 
 
@@ -155,7 +156,7 @@ public class Test1OptionalCreationAndFetchingValues {
         Optional<Integer> anotherOptionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * TODO:
+         * DONE:
          *  Replace the "null" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
          *  Check API: java.util.Optional.isPresent()
@@ -163,7 +164,7 @@ public class Test1OptionalCreationAndFetchingValues {
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    10,
+                    anotherOptionalInteger.get(),
                     "This call should throw a NoSuchElementException");
         });
 

--- a/java-optional/src/solutions/java/none/cvg/optional/STest2OptionalConditionalFetchingTest.java
+++ b/java-optional/src/solutions/java/none/cvg/optional/STest2OptionalConditionalFetchingTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Optional - conditional fetch non-null value or alternative")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class STest2OptionalConditionalFetching {
+public class STest2OptionalConditionalFetchingTest {
 
     @BeforeEach
     public void setUp() {

--- a/java-optional/src/solutions/java/none/cvg/optional/STest3StreamsAndOptionalsTest.java
+++ b/java-optional/src/solutions/java/none/cvg/optional/STest3StreamsAndOptionalsTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @DisplayName("Optional - using Optionals in collections with Stream API")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class STest3StreamsAndOptionals {
+public class STest3StreamsAndOptionalsTest {
 
     private Set<NameValuePair> expectedSetOfNameValuePairs;
     private Set<String> namesSet = new HashSet<>();

--- a/java-optional/src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValuesTest.java
+++ b/java-optional/src/test/java/none/cvg/optional/Test1OptionalCreationAndFetchingValuesTest.java
@@ -1,16 +1,15 @@
 package none.cvg.optional;
 
-import java.util.NoSuchElementException;
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -19,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /*
- * DONE:
+ * TODO:
  *  This test aims at understanding the basic features of Optional
  *  Each unsolved test provides a few hints that will allow the kata-taker to manually solve
  *  the exercise.
@@ -28,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("java.util.Optional Creation And Getting value")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class STest1OptionalCreationAndFetchingValues {
+public class Test1OptionalCreationAndFetchingValuesTest {
 
     @BeforeEach
     public void setUp() {
@@ -36,16 +35,16 @@ public class STest1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create an empty Optional")
-    @Tag("PASSING")
+    @Tag("TODO")
     @Order(1)
     public void emptyOptional() {
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "null" to create an empty Optional.
          *  Check API: java.util.Optional.empty()
          */
-        Optional<String> optionalEmptyString = Optional.empty();
+        Optional<String> optionalEmptyString = null;
 
         assertTrue(optionalEmptyString instanceof Optional,
                 "The optionalEmptyString should be an instance of Optional");
@@ -56,18 +55,18 @@ public class STest1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create an Optional from a variable")
-    @Tag("PASSING")
+    @Tag("TODO")
     @Order(2)
     public void createOptionalFromValue() {
 
         Integer anInteger = 10;
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "null" to create an Optional for anInteger.
          *  Check API: java.util.Optional.of(?)
          */
-        Optional<Integer> optionalForInteger = Optional.of(anInteger);
+        Optional<Integer> optionalForInteger = null;
 
         assertTrue(optionalForInteger instanceof Optional,
                 "The optionalEmptyString should be an instance of Optional");
@@ -78,18 +77,18 @@ public class STest1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("create a nullable Optional from a variable")
-    @Tag("PASSING")
+    @Tag("TODO")
     @Order(3)
     public void createNullableOptionalFromValue() {
 
         Integer anInteger = null;
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "null" to create a nullable Optional for anInteger.
          *  Check API: java.util.Optional.ofNullable(?)
          */
-        Optional<Integer> optionalNullableInteger = Optional.ofNullable(anInteger);
+        Optional<Integer> optionalNullableInteger = Optional.of(10);
 
         assertTrue(optionalNullableInteger instanceof Optional,
                 "The optionalNullableInteger should be an instance of Optional");
@@ -100,7 +99,7 @@ public class STest1OptionalCreationAndFetchingValues {
 
     @Test
     @DisplayName("check a non-null Optional has a value")
-    @Tag("PASSING")
+    @Tag("TODO")
     @Order(4)
     public void checkOptionalForNonNullValueIsPresent() {
 
@@ -109,11 +108,11 @@ public class STest1OptionalCreationAndFetchingValues {
         Optional<Integer> optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "false" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.isPresent()
          */
-        assertTrue(optionalInteger.isPresent(),
+        assertTrue(false,
                 "The optionalNullableInteger should be present");
 
 
@@ -122,18 +121,18 @@ public class STest1OptionalCreationAndFetchingValues {
         optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "false" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.isPresent()
          */
-        assertFalse(optionalInteger.isPresent(),
+        assertFalse(true,
                 "The optionalNullableInteger should not be present");
 
     }
 
     @Test
     @DisplayName("fetch from a non-null and from a null holding Optional")
-    @Tag("PASSING")
+    @Tag("TODO")
     @Order(5)
     public void getValueFromOptionalForNonNullValue() {
 
@@ -142,12 +141,12 @@ public class STest1OptionalCreationAndFetchingValues {
         Optional<Integer> optionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * DONE:
-         *  Replace the "null" to check that the Optional has a non-null value.
+         * TODO:
+         *  Replace the "11" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.get()
          */
         assertEquals(10,
-                optionalInteger.get(),
+                11,
                 "The optionalNullableInteger should be present");
 
 
@@ -156,7 +155,7 @@ public class STest1OptionalCreationAndFetchingValues {
         Optional<Integer> anotherOptionalInteger = Optional.ofNullable(anInteger);
 
         /*
-         * DONE:
+         * TODO:
          *  Replace the "null" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
          *  Check API: java.util.Optional.isPresent()
@@ -164,7 +163,7 @@ public class STest1OptionalCreationAndFetchingValues {
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    anotherOptionalInteger.get(),
+                    10,
                     "This call should throw a NoSuchElementException");
         });
 

--- a/java-optional/src/test/java/none/cvg/optional/Test2OptionalConditionalFetchingTest.java
+++ b/java-optional/src/test/java/none/cvg/optional/Test2OptionalConditionalFetchingTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @DisplayName("Optional - conditional fetch non-null value or alternative")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class Test2OptionalConditionalFetching {
+public class Test2OptionalConditionalFetchingTest {
 
     @BeforeEach
     public void setUp() {

--- a/java-optional/src/test/java/none/cvg/optional/Test3StreamsAndOptionalsTest.java
+++ b/java-optional/src/test/java/none/cvg/optional/Test3StreamsAndOptionalsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @DisplayName("Optional - using Optionals in collections with Stream API")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-public class Test3StreamsAndOptionals {
+public class Test3StreamsAndOptionalsTest {
 
     private Set<NameValuePair> expectedSetOfNameValuePairs;
     private Set<String> namesSet = new HashSet<>();


### PR DESCRIPTION
> By default, the Surefire Plugin will automatically include all test classes with the following wildcard patterns:
> "**/Test*.java" - includes all of its subdirectories and all Java filenames that start with "Test".
> "**/*Test.java" - includes all of its subdirectories and all Java filenames that end with "Test".
> "**/*Tests.java" - includes all of its subdirectories and all Java filenames that end with "Tests" 
> "**/*TestCase.java" - includes all of its subdirectories and all Java filenames that end with "TestCase". 
[Source](http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html)

Classes in java-optional did not follow any of listed above, so they was not run at all.

This fixes  #6 