### PR TITLE
Correcting spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ From http://wikipedia: Kata originally were teaching and training methods by whi
 
 From http://codekata.com: Code Kata is an attempt to bring the element of practice to software development. A kata is an exercise in karate where you repeat a form many, many times, making little improvements in each. The intent behind code kata is similar. Each is a short exercise (perhaps 30 minutes to an hour long). Some involve programming, and can be coded in many different ways. Some are open ended, and involve thinking about the issues behind programming. These are unlikely to have a single correct answer.
 
-Code Katas were first introduced by Dave Thomas and are an great tool to practice programming something new.
+Code katas were first introduced by Dave Thomas and are an great tool to practice programming something new.
 
 ## So, what is in this repo?
 
@@ -27,13 +27,13 @@ This Git repo is a collection of several code katas about features, utilities an
 
 The general structure of each project is a maven quickstart project with a pom.xml, a src directory that contains at least two directories. Code Katas are available under the src/test/java while solutions are under src/solutions/java under each module. The code katas typically contain failing tests with TODO markers that need to be fixed in order to fix the test, 
 
-**Remember, the src/solutions may not be the perfect way to solve the kata, maybe a solution you come up with is better**. Feel free to submit a pull request if you think you have a better solition than the one you find.
+**Remember, the src/solutions may not be the perfect way to solve the kata, maybe a solution you come up with is better**. Feel free to submit a pull request if you think you have a better solution than the one you find.
 
-### Current Katas
+### Current katas
 
-1. `java-handles`: This Kata is for understanding Java Reflection and `sun.misc.Unsafe` usages and also to learn the alternates for those in Method Handles API and VarHandles API in more recent version of Java.
-1. `java-datetime`: This Kata is for learning the Java Time API introduced in Java 8, that replaces the java.util.Date and java.util.Calendar with a more humane and extensible API.
-1. `java-optionals`: This Kata is for learning the Java Optional API, as a repacement for null-checks and unexpected `NullPointerException`s that crop up causing developer unhappiness and/or application instability issues.
+1. `java-handles`: This kata is for understanding Java Reflection and `sun.misc.Unsafe` usages and also to learn the alternates for those in Method Handles API and VarHandles API in more recent version of Java.
+1. `java-datetime`: This kata is for learning the Java Time API introduced in Java 8, that replaces the java.util.Date and java.util.Calendar with a more humane and extensible API.
+1. `java-optional`: This kata is for learning the Java Optional API, as a replacement for null-checks and unexpected `NullPointerException`s that crop up causing developer unhappiness and/or application instability issues.
 
 More katas will be added, feel free to contribute if you have ideas.
 


### PR DESCRIPTION
Aside from obvious mistakes, like the 'solution' one, several
"kata/Kata" spelling were corrected.

According to dictionaries the word is "kata" and its plural is "katas".
In general a Kata about coding is called "code kata" or "coding kata".
So all occurrences of this noun were corrected.

The unchanged occurrences are either a name (the page 'CodeKata'
of D. Thomas) or mistakes inside a quote which must not be corrected
as the quote is then falsified. For example the quote "Code Kata is an
attempt to bring..." is a mistake by D. Thomas himself because he
references to his own page, so the correct spelling would be "CodeKata"
like in the title of the page or the blog posts.

Issue: #10