### PR TITLE
TODO instructions improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ buildNumber.properties
 !/.mvn/wrapper/maven-wrapper.jar
 /.idea/
 **/*.iml
+
+# Ignore eclipse settings
+.classpath
+.project
+.settings
+

--- a/java-optional/src/solutions/java/none/cvg/optional/TestSolution1OptionalCreationAndFetchingValues.java
+++ b/java-optional/src/solutions/java/none/cvg/optional/TestSolution1OptionalCreationAndFetchingValues.java
@@ -159,12 +159,12 @@ public class TestSolution1OptionalCreationAndFetchingValues {
          * DONE:
          *  Replace the "null" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
-         *  Check API: java.util.Optional.orElseThrow()
+         *  Check API: java.util.Optional.get()
          */
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    anotherOptionalInteger.orElseThrow(),
+                    anotherOptionalInteger.get(),
                     "This call should throw a NoSuchElementException");
         });
 

--- a/java-optional/src/solutions/java/none/cvg/optional/TestSolution1OptionalCreationAndFetchingValues.java
+++ b/java-optional/src/solutions/java/none/cvg/optional/TestSolution1OptionalCreationAndFetchingValues.java
@@ -159,12 +159,12 @@ public class TestSolution1OptionalCreationAndFetchingValues {
          * DONE:
          *  Replace the "null" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
-         *  Check API: java.util.Optional.isPresent()
+         *  Check API: java.util.Optional.orElseThrow()
          */
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    anotherOptionalInteger.get(),
+                    anotherOptionalInteger.orElseThrow(),
                     "This call should throw a NoSuchElementException");
         });
 

--- a/java-optional/src/test/java/none/cvg/optional/TestKata1OptionalCreationAndFetchingValues.java
+++ b/java-optional/src/test/java/none/cvg/optional/TestKata1OptionalCreationAndFetchingValues.java
@@ -156,14 +156,14 @@ public class TestKata1OptionalCreationAndFetchingValues {
 
         /*
          * TODO:
-         *  Replace the "11" to get the Optional has a null value.
+         *  Replace the "10" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
          *  Check API: java.util.Optional.get()
          */
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    11,
+                    10,
                     "This call should throw a NoSuchElementException");
         });
 

--- a/java-optional/src/test/java/none/cvg/optional/TestKata1OptionalCreationAndFetchingValues.java
+++ b/java-optional/src/test/java/none/cvg/optional/TestKata1OptionalCreationAndFetchingValues.java
@@ -122,7 +122,7 @@ public class TestKata1OptionalCreationAndFetchingValues {
 
         /*
          * TODO:
-         *  Replace the "false" to check that the Optional has a non-null value.
+         *  Replace the "true" to check that the Optional has a non-null value.
          *  Check API: java.util.Optional.isPresent()
          */
         assertFalse(true,
@@ -156,14 +156,14 @@ public class TestKata1OptionalCreationAndFetchingValues {
 
         /*
          * TODO:
-         *  Replace the "null" to get the Optional has a null value.
+         *  Replace the "11" to get the Optional has a null value.
          *  Verify that the call throws a NoSuchElementException
-         *  Check API: java.util.Optional.isPresent()
+         *  Check API: java.util.Optional.get()
          */
         assertThrows(NoSuchElementException.class, () -> {
 
             assertNotEquals(10,
-                    10,
+                    11,
                     "This call should throw a NoSuchElementException");
         });
 


### PR DESCRIPTION
At places the `TODO` instruction asks for replacing a value which is not
exactly there.

Improvement in `TestSolution1OptionalCreationAndFetchingValues.java`:
from the `@apiNote` of `Optional.get()`, the preferred alternative is
`Optional.orElseThrow()`.